### PR TITLE
Disconnect GH handlers from webhook HTTP request context

### DIFF
--- a/server/handler/check_run.go
+++ b/server/handler/check_run.go
@@ -34,6 +34,8 @@ func (h *CheckRun) Handles() []string {
 }
 
 func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+	ctx = context.Background()
+
 	var event github.CheckRunEvent
 
 	if err := json.Unmarshal(payload, &event); err != nil {

--- a/server/handler/check_run.go
+++ b/server/handler/check_run.go
@@ -54,6 +54,7 @@ func handleCheckRun(config *ServerConfig, event github.CheckRunEvent) {
 	prs := event.GetCheckRun().PullRequests
 	if len(prs) == 0 {
 		logger.Debug().Msg("Doing nothing since status change event affects no open pull requests")
+		return
 	}
 
 	for _, pr := range prs {

--- a/server/handler/check_run.go
+++ b/server/handler/check_run.go
@@ -33,14 +33,8 @@ func (h *CheckRun) Handles() []string {
 	return []string{"check_run"}
 }
 
-func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
-	ctx = context.Background()
-
-	var event github.CheckRunEvent
-
-	if err := json.Unmarshal(payload, &event); err != nil {
-		return errors.Wrap(err, "failed to parse check_run event payload")
-	}
+func handleCheckRun(config *ServerConfig, event github.CheckRunEvent) {
+	ctx := context.Background()
 
 	repo := event.GetRepo()
 	installationID := githubapp.GetInstallationIDFromEvent(&event)
@@ -49,18 +43,17 @@ func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, pay
 
 	if event.GetAction() != "completed" {
 		logger.Debug().Msgf("Doing nothing since check_run action was %q instead of 'completed'", event.GetAction())
-		return nil
 	}
 
-	client, err := h.Config.ClientCreator.NewInstallationClient(installationID)
+	client, err := config.ClientCreator.NewInstallationClient(installationID)
 	if err != nil {
-		return errors.Wrap(err, "failed to instantiate github client")
+		logger.Error().Err(err).Msg("failed to instantiate github client")
+		return
 	}
 
 	prs := event.GetCheckRun().PullRequests
 	if len(prs) == 0 {
 		logger.Debug().Msg("Doing nothing since status change event affects no open pull requests")
-		return nil
 	}
 
 	for _, pr := range prs {
@@ -70,15 +63,26 @@ func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, pay
 
 		fullPR, _, err := client.PullRequests.Get(ctx, repo.GetOwner().GetLogin(), repo.GetName(), pr.GetNumber())
 		if err != nil {
-			return errors.Wrapf(err, "failed to fetch PR number %q for CheckRun", pr.GetNumber())
+			logger.Error().Err(err).Msgf("failed to fetch PR number %q for CheckRun", pr.GetNumber())
+			continue
 		}
 		pullCtx := pull.NewGithubContext(client, fullPR)
 
 		logger := logger.With().Int(githubapp.LogKeyPRNum, pr.GetNumber()).Logger()
-		if err := ProcessPullRequest(logger.WithContext(ctx), h.Config, pullCtx, client, fullPR.GetBase().GetRef()); err != nil {
-			logger.Error().Err(errors.WithStack(err)).Msg("Error processing pull request")
+		if err := ProcessPullRequest(logger.WithContext(ctx), config, pullCtx, client, fullPR.GetBase().GetRef()); err != nil {
+			logger.Error().Err(err).Msg("Error processing pull request")
 		}
 	}
+}
+
+func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+	var event github.CheckRunEvent
+
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return errors.Wrap(err, "failed to parse check_run event payload")
+	}
+
+	go handleCheckRun(h.Config, event)
 
 	return nil
 }

--- a/server/handler/issue_comment.go
+++ b/server/handler/issue_comment.go
@@ -34,6 +34,8 @@ func (h *IssueComment) Handles() []string {
 }
 
 func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+	ctx = context.Background()
+
 	var event github.IssueCommentEvent
 	if err := json.Unmarshal(payload, &event); err != nil {
 		return errors.Wrap(err, "failed to parse issue comment payload")

--- a/server/handler/issue_comment.go
+++ b/server/handler/issue_comment.go
@@ -33,13 +33,8 @@ func (h *IssueComment) Handles() []string {
 	return []string{"issue_comment"}
 }
 
-func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
-	ctx = context.Background()
-
-	var event github.IssueCommentEvent
-	if err := json.Unmarshal(payload, &event); err != nil {
-		return errors.Wrap(err, "failed to parse issue comment payload")
-	}
+func handleIssueComment(config *ServerConfig, event github.IssueCommentEvent) {
+	ctx := context.Background()
 
 	repo := event.GetRepo()
 	owner := repo.GetOwner().GetLogin()
@@ -48,22 +43,34 @@ func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string,
 	installationID := githubapp.GetInstallationIDFromEvent(&event)
 	ctx, logger := githubapp.PreparePRContext(ctx, installationID, repo, number)
 
-	client, err := h.Config.ClientCreator.NewInstallationClient(installationID)
+	client, err := config.ClientCreator.NewInstallationClient(installationID)
 	if err != nil {
-		return errors.Wrap(err, "failed to instantiate github client")
+		logger.Error().Err(err).Msg("failed to instantiate github client")
+		return
 	}
 
 	pr, _, err := client.PullRequests.Get(ctx, repo.GetOwner().GetLogin(), repo.GetName(), number)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get pull request %s/%s#%d", owner, repoName, number)
+		logger.Error().Err(err).Msgf("failed to get pull request %s/%s#%d", owner, repoName, number)
+		return
 	}
 	pullCtx := pull.NewGithubContext(client, pr)
 
-	if err := ProcessPullRequest(ctx, h.Config, pullCtx, client, pr.GetBase().GetRef()); err != nil {
-		logger.Error().Err(errors.WithStack(err)).Msg("Error processing pull request")
+	if err := ProcessPullRequest(ctx, config, pullCtx, client, pr.GetBase().GetRef()); err != nil {
+		logger.Error().Err(err).Msg("Error processing pull request")
+	}
+}
+
+func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+	var event github.IssueCommentEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return errors.Wrap(err, "failed to parse issue comment payload")
 	}
 
+	go handleIssueComment(h.Config, event)
+
 	return nil
+
 }
 
 // type assertion

--- a/server/handler/pull_request.go
+++ b/server/handler/pull_request.go
@@ -33,13 +33,8 @@ func (h *PullRequest) Handles() []string {
 	return []string{"pull_request"}
 }
 
-func (h *PullRequest) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
-	ctx = context.Background()
-
-	var event github.PullRequestEvent
-	if err := json.Unmarshal(payload, &event); err != nil {
-		return errors.Wrap(err, "failed to parse pull request event payload")
-	}
+func handlePullRequest(config *ServerConfig, event github.PullRequestEvent) {
+	ctx := context.Background()
 
 	repo := event.GetRepo()
 	owner := repo.GetOwner().GetLogin()
@@ -50,23 +45,35 @@ func (h *PullRequest) Handle(ctx context.Context, eventType, deliveryID string, 
 
 	if event.GetAction() == "closed" {
 		logger.Debug().Msg("Doing nothing since pull request is closed")
-		return nil
+		return
 	}
 
-	client, err := h.Config.ClientCreator.NewInstallationClient(installationID)
+	client, err := config.ClientCreator.NewInstallationClient(installationID)
 	if err != nil {
-		return errors.Wrap(err, "failed to instantiate github client")
+		logger.Error().Err(err).Msg("failed to instantiate github client")
+		return
 	}
 
 	pr, _, err := client.PullRequests.Get(ctx, owner, repoName, number)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get pull request %s/%s#%d", owner, repoName, number)
+		logger.Error().Err(err).Msgf("failed to get pull request %s/%s#%d", owner, repoName, number)
+		return
 	}
 	pullCtx := pull.NewGithubContext(client, pr)
 
-	if err := ProcessPullRequest(ctx, h.Config, pullCtx, client, pr.GetBase().GetRef()); err != nil {
-		logger.Error().Err(errors.WithStack(err)).Msg("Error updating pull request")
+	if err := ProcessPullRequest(ctx, config, pullCtx, client, pr.GetBase().GetRef()); err != nil {
+		logger.Error().Err(err).Msg("Error updating pull request")
 	}
+
+}
+
+func (h *PullRequest) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+	var event github.PullRequestEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return errors.Wrap(err, "failed to parse pull request event payload")
+	}
+
+	go handlePullRequest(h.Config, event)
 
 	return nil
 }

--- a/server/handler/pull_request.go
+++ b/server/handler/pull_request.go
@@ -34,6 +34,8 @@ func (h *PullRequest) Handles() []string {
 }
 
 func (h *PullRequest) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+	ctx = context.Background()
+
 	var event github.PullRequestEvent
 	if err := json.Unmarshal(payload, &event); err != nil {
 		return errors.Wrap(err, "failed to parse pull request event payload")

--- a/server/handler/pull_request_review.go
+++ b/server/handler/pull_request_review.go
@@ -34,6 +34,8 @@ func (h *PullRequestReview) Handles() []string {
 }
 
 func (h *PullRequestReview) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+	ctx = context.Background()
+
 	var event github.PullRequestReviewEvent
 	if err := json.Unmarshal(payload, &event); err != nil {
 		return errors.Wrap(err, "failed to parse pull request review event payload")

--- a/server/handler/push.go
+++ b/server/handler/push.go
@@ -34,6 +34,8 @@ func (h *Push) Handles() []string {
 }
 
 func (h *Push) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+	ctx = context.Background()
+
 	var event github.PushEvent
 	if err := json.Unmarshal(payload, &event); err != nil {
 		return errors.Wrap(err, "failed to parse push event payload")

--- a/server/handler/status.go
+++ b/server/handler/status.go
@@ -34,6 +34,8 @@ func (h *Status) Handles() []string {
 }
 
 func (h *Status) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+	ctx = context.Background()
+
 	var event github.StatusEvent
 	if err := json.Unmarshal(payload, &event); err != nil {
 		return errors.Wrap(err, "failed to parse status event payload")

--- a/server/handler/status.go
+++ b/server/handler/status.go
@@ -33,13 +33,8 @@ func (h *Status) Handles() []string {
 	return []string{"status"}
 }
 
-func (h *Status) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
-	ctx = context.Background()
-
-	var event github.StatusEvent
-	if err := json.Unmarshal(payload, &event); err != nil {
-		return errors.Wrap(err, "failed to parse status event payload")
-	}
+func handleStatus(config *ServerConfig, event github.StatusEvent) {
+	ctx := context.Background()
 
 	repo := event.GetRepo()
 	owner := repo.GetOwner().GetLogin()
@@ -49,32 +44,44 @@ func (h *Status) Handle(ctx context.Context, eventType, deliveryID string, paylo
 
 	if event.GetState() != "success" {
 		logger.Debug().Msgf("Doing nothing since context state for %q was %q", event.GetContext(), event.GetState())
-		return nil
+		return
 	}
 
-	client, err := h.Config.ClientCreator.NewInstallationClient(installationID)
+	client, err := config.ClientCreator.NewInstallationClient(installationID)
 	if err != nil {
-		return errors.Wrap(err, "failed to instantiate github client")
+		logger.Error().Err(err).Msg("failed to instantiate github client")
+		return
 	}
 
 	prs, err := pull.ListOpenPullRequestsForSHA(ctx, client, owner, repoName, event.GetSHA())
 	if err != nil {
-		return errors.Wrap(err, "failed to determine open pull requests matching the status context change")
+		logger.Error().Err(err).Msg("failed to determine open pull requests matching the status context change")
+		return
 	}
 
 	if len(prs) == 0 {
 		logger.Debug().Msg("Doing nothing since status change event affects no open pull requests")
-		return nil
+		return
 	}
 
 	for _, pr := range prs {
 		pullCtx := pull.NewGithubContext(client, pr)
 		logger := logger.With().Int(githubapp.LogKeyPRNum, pr.GetNumber()).Logger()
 
-		if err := ProcessPullRequest(ctx, h.Config, pullCtx, client, pr.GetBase().GetRef()); err != nil {
-			logger.Error().Err(errors.WithStack(err)).Msg("Error updating pull request")
+		if err := ProcessPullRequest(ctx, config, pullCtx, client, pr.GetBase().GetRef()); err != nil {
+			logger.Error().Err(err).Msg("Error updating pull request")
 		}
 	}
+
+}
+
+func (h *Status) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+	var event github.StatusEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return errors.Wrap(err, "failed to parse status event payload")
+	}
+
+	go handleStatus(h.Config, event)
 
 	return nil
 }


### PR DESCRIPTION
Handlers were using webhook HTTP request context, so that if GH webhook client
disconnected while the handler was still running the handler failed.