### PR TITLE
Update list of Go versions to test Bulldozer against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
   - $HOME/.cache/go-build
   - $GOPATH/pkg/mod
 go:
+- tip
 - 1.15.x # see version in Makefile:check-go-mod
 - 1.14.x
 - 1.13.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
   - $HOME/.cache/go-build
   - $GOPATH/pkg/mod
 go:
-- 1.15.x
+- 1.15.x # see version in Makefile:check-go-mod
 - 1.14.x
 - 1.13.x
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ cache:
   - $HOME/.cache/go-build
   - $GOPATH/pkg/mod
 go:
-- tip
+- 1.15.x
+- 1.14.x
 - 1.13.x
 install: true
 script:

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,14 @@ check: check-go-mod check-vet check-test
 
 check-go-mod:
 	@echo CHECK GO.MOD/GO.SUM
-	@go mod tidy
-	@if [ -n "$$(git status --porcelain)" ]; then \
-		git status -v; \
-		exit 1; \
+	@if [ "x$$TRAVIS_GO_VERSION" != x1.15.x ]; then \
+		echo "Skipping, not a current stable version"; \
+	else \
+		go mod tidy; \
+		if [ -n "$$(git status --porcelain)" ]; then \
+			git status -v; \
+			exit 1; \
+		fi; \
 	fi
 
 check-vet:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 check: check-go-mod check-vet check-test
 
+STABLE_GO_VERSION=1.15.x
+
 check-go-mod:
 	@echo CHECK GO.MOD/GO.SUM
-	@if [ "x$$TRAVIS_GO_VERSION" != x1.15.x ]; then \
+	@if [ "x$$TRAVIS_GO_VERSION" != "x$(STABLE_GO_VERSION)" ]; then \
 		echo "Skipping, not a current stable version"; \
 	else \
 		go mod tidy; \


### PR DESCRIPTION
Also only check `go.mod` against current stable Go version.