### PR TITLE
Use x/crypto/x509roots/fallback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,6 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
 	goji.io v2.0.2+incompatible
+	golang.org/x/crypto/x509roots/fallback v0.0.0-20230609172314-d0b316056be8
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -318,6 +318,8 @@ golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e h1:1SzTfNOXwIS2oWiMF+6qu0OUDKb0dauo6MoDUQyu+yU=
 golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
+golang.org/x/crypto/x509roots/fallback v0.0.0-20230609172314-d0b316056be8 h1:aIWbGcufS3YCIzgqzHuhioLSN8wyyifhUROoAeEXMRc=
+golang.org/x/crypto/x509roots/fallback v0.0.0-20230609172314-d0b316056be8/go.mod h1:kNa9WdvYnzFwC79zRpLRMJbdEFlhyM5RPFBBZp/wWH8=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/main.go
+++ b/main.go
@@ -19,8 +19,8 @@ import (
 	"os"
 
 	"github.com/palantir/go-baseapp/pkg/errfmt"
-
 	"github.com/ridge/bulldozer/cmd"
+	_ "golang.org/x/crypto/x509roots/fallback"
 )
 
 func main() {


### PR DESCRIPTION
Bulldozer no longer needs external CA bundle to make HTTPS requests.